### PR TITLE
fix incorrect file reference in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,9 +6,9 @@
     "dependencies": {
         "lodash/lodash": "2.4.1"
     },
-    "main": "dist/lodash-contrib.js",
+    "main": "lodash-contrib.js",
     "scripts": [
-        "dist/lodash-contrib.js"
+        "lodash-contrib.js"
     ],
     "license": "MIT"
 }

--- a/component.json
+++ b/component.json
@@ -8,7 +8,21 @@
     },
     "main": "lodash-contrib.js",
     "scripts": [
-        "lodash-contrib.js"
+        "lodash-contrib.js",
+        "_.collections.walk.js",
+        "_.function.arity.js",
+        "_.function.combinators.js",
+        "_.function.dispatch.js",
+        "_.function.iterators.js",
+        "_.function.predicates.js",
+        "_.object.builders.js",
+        "_.object.selectors.js",
+        "_.util.operators.js",
+        "_.util.strings.js",
+        "_.util.trampolines.js",
+        "common-js/_.array.builders.js",
+        "common-js/_.array.selectors.js",
+        "common-js/_.util.existential.js"
     ],
     "license": "MIT"
 }


### PR DESCRIPTION
The file `dist/lodash-contrib.js` is not the right file to expose as it depends on the `common-js` folder and its assets.

Instead, moved the reference to the `lodash-contrib.js` file in the root folder and also included all dependent files.