### PR TITLE
Chunk padding

### DIFF
--- a/common-js/_.array.builders.js
+++ b/common-js/_.array.builders.js
@@ -35,6 +35,7 @@ module.exports = function(_) {
     // the third argument to fill in the tail chunk when n is
     // not sufficient to build chunks of the same size.
     chunk: function(array, n, pad) {
+      var args = arguments;
       var p = function(array) {
         if (array == null) return [];
 
@@ -43,7 +44,7 @@ module.exports = function(_) {
         if (n === _.size(part)) {
           return _.cons(part, p(_.drop(array, n)));
         }
-        else if (pad) {
+        else if (args.length === 3) {
           pad = _.isArray(pad) ? pad : _.repeat(n, pad);
           return [_.take(_.cat(part, pad), n)];
         }

--- a/common-js/_.array.builders.js
+++ b/common-js/_.array.builders.js
@@ -43,8 +43,12 @@ module.exports = function(_) {
         if (n === _.size(part)) {
           return _.cons(part, p(_.drop(array, n)));
         }
+        else if (pad) {
+          pad = _.isArray(pad) ? pad : _.repeat(n, pad);
+          return [_.take(_.cat(part, pad), n)];
+        }
         else {
-          return pad ? [_.take(_.cat(part, pad), n)] : [];
+            return [];
         }
       };
 

--- a/test/array.builders.js
+++ b/test/array.builders.js
@@ -66,6 +66,7 @@ $(document).ready(function() {
     deepEqual(_.chunk(c, 3, [7,8]), [[0,1,2],[3,4,5],[6,7,8]], 'should allow one to specify a padding array');
     deepEqual(_.chunk(b, 3, 9), [[0,1,2],[3,4,9]], 'should allow one to specify a padding value');
     deepEqual(_.chunk(a, 3, 9), [[0,1,2],[3,9,9]], 'should repeat the padding value');
+    deepEqual(_.chunk(a, 3, undefined), [[0,1,2],[3,undefined,undefined]], 'should allow padding with undefined');
   });
 
   test("chunkAll", function() {

--- a/test/array.builders.js
+++ b/test/array.builders.js
@@ -65,6 +65,7 @@ $(document).ready(function() {
 
     deepEqual(_.chunk(c, 3, [7,8]), [[0,1,2],[3,4,5],[6,7,8]], 'should allow one to specify a padding array');
     deepEqual(_.chunk(b, 3, 9), [[0,1,2],[3,4,9]], 'should allow one to specify a padding value');
+    deepEqual(_.chunk(a, 3, 9), [[0,1,2],[3,9,9]], 'should repeat the padding value');
   });
 
   test("chunkAll", function() {


### PR DESCRIPTION
Hi,

The chunk function doesn't behave quite as described in the docs which state that a non-array padding argument is repeated to fill out the final chunk if it's incomplete.

Also trying to pad with a falsey value was indistinguishable from chunking without a pad argument - I used arguments.length to fix this.

There's also a small typo in the documentation for the chunk function:

```javascript
_.chunk([0,1,2,3,4], 3, '_');
//=> , [[0,1,2],[3,'_','_']]
```

should read:
```javascript
_.chunk([0,1,2,3], 3, '_');
//=> , [[0,1,2],[3,'_','_']]
```

(i.e. the '4' from the input array should be removed to match the output). I didn't update the docs to comply with CONTRIBUTING.md.

Thanks
Dave