### PR TITLE
Update lodash reference in dependency list in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "repo": "TheNodeILs/lodash-contrib",
     "version": "393.0.0",
     "dependencies": {
-        "lodash/lodash": "3.9.3"
+        "lodash": "3.9.3"
     },
     "main": "dist/lodash-contrib.js",
     "scripts": [


### PR DESCRIPTION
When I bower installed lodash-contrib this morning, it said 

`bower ENOTFOUND     Package lodash/lodash=lodash/lodash not found`

It appears that lodash/lodash is not registered in the Bower registry. Therefore, I updated the reference to lodash in bower dependency list to lodash, which resolved the issue.